### PR TITLE
fix: 添加对特定访问路径的处理以支持Cloudflare位置请求

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -297,7 +297,7 @@ export default {
                     return new Response(订阅内容, { status: 200, headers: responseHeaders });
                 }
                 return new Response('无效的订阅TOKEN', { status: 403 });
-            }
+            } else if (访问路径 === 'locations') return fetch(new Request('https://speed.cloudflare.com/locations'));
         } else if (管理员密码) {// ws代理
             await 反代参数获取(request);
             return await 处理WS请求(request, userID);


### PR DESCRIPTION
This pull request adds a new feature to the `_worker.js` file, allowing requests to the `locations` path to be proxied to the Cloudflare speed test locations endpoint. This improves the functionality of the worker by supporting an additional route for users.

New route handling:

* Added support for the `locations` path, which proxies requests to `https://speed.cloudflare.com/locations` when accessed.