### PR TITLE
fix: 统一处理反代IP和SOCKS5账号逻辑，确保小写格式和默认值

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -17,7 +17,7 @@ export default {
         if (env.PROXYIP) {
             const proxyIPs = await 整理成数组(env.PROXYIP);
             反代IP = proxyIPs[Math.floor(Math.random() * proxyIPs.length)];
-        } else 反代IP = 反代IP ? 反代IP : request.cf.colo + '.PrOxYIp.CmLiUsSsS.nEt';
+        } else 反代IP = (request.cf.colo + '.PrOxYIp.CmLiUsSsS.nEt').toLowerCase();
         const 访问IP = request.headers.get('X-Real-IP') || request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || request.headers.get('True-Client-IP') || request.headers.get('Fly-Client-IP') || request.headers.get('X-Appengine-Remote-Addr') || request.headers.get('X-Forwarded-For') || request.headers.get('X-Real-IP') || request.headers.get('X-Cluster-Client-IP') || request.cf?.clientTcpRtt || '未知IP';
         if (env.GO2SOCKS5) SOCKS5白名单 = await 整理成数组(env.GO2SOCKS5);
         if (!upgradeHeader || upgradeHeader !== 'websocket') {
@@ -1061,8 +1061,8 @@ async function 反代参数获取(request) {
     const pathLower = pathname.toLowerCase();
 
     // 初始化
-    我的SOCKS5账号 = searchParams.get('socks5') || searchParams.get('http') || 我的SOCKS5账号;
-    启用SOCKS5全局反代 = searchParams.has('globalproxy') || 启用SOCKS5全局反代;
+    我的SOCKS5账号 = searchParams.get('socks5') || searchParams.get('http') || null;
+    启用SOCKS5全局反代 = searchParams.has('globalproxy') || false;
 
     // 统一处理反代IP参数 (优先级最高,使用正则一次匹配)
     const proxyMatch = pathLower.match(/\/(proxyip[.=]|pyip=|ip=)(.+)/);
@@ -1108,7 +1108,7 @@ async function 反代参数获取(request) {
             console.error('解析SOCKS5地址失败:', err.message);
             启用SOCKS5反代 = null;
         }
-    }
+    } else 启用SOCKS5反代 = null;
 }
 
 async function 获取SOCKS5账号(address) {


### PR DESCRIPTION
This pull request makes several improvements to the proxy IP and SOCKS5 handling logic in `_worker.js`. The changes mainly focus on standardizing IP formatting, ensuring proper initialization of proxy-related variables, and improving error handling for SOCKS5 proxy parsing.

**Proxy IP handling:**
* Standardized the default proxy IP format by always converting it to lowercase, which helps avoid inconsistencies due to case sensitivity.

**SOCKS5 proxy logic improvements:**
* Ensured that the `我的SOCKS5账号` variable is initialized to `null` if not provided, and `启用SOCKS5全局反代` is set to `false` by default, preventing unintended carry-over of previous values.
* Improved error handling by explicitly setting `启用SOCKS5反代` to `null` when SOCKS5 address parsing fails or is not attempted, ensuring a clear and consistent state.