### PR TITLE
Beta2.0

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -867,7 +867,7 @@ async function 读取config_JSON(env, hostname, userID, 重置配置 = false) {
         },
         订阅转换配置: {
             SUBAPI: "https://SUBAPI.cmliussss.net",
-            SUBCONFIG: "https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/config/ACL4SSR_Mini_MultiMode_CF.ini",
+            SUBCONFIG: "https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/config/ACL4SSR_Online_Mini_MultiMode_CF.ini",
             SUBEMOJI: false,
         },
         反代: {


### PR DESCRIPTION
This pull request updates the subscription configuration URL in the `读取config_JSON` function to point to a new source. This ensures that the configuration is fetched from the correct repository and file.

Configuration source update:

* Changed the `SUBCONFIG` URL in the `订阅转换配置` object to use `https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/config/ACL4SSR_Mini_MultiMode_CF.ini` instead of the previous ACL4SSR repository and file.