### PR TITLE
fix: 修正用户ID生成逻辑，确保UUID格式正确

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -13,7 +13,7 @@ export default {
         const userIDMD5 = await MD5MD5(管理员密码 + 加密秘钥);
         const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
         const envUUID = env.UUID || env.uuid;
-        const userID = (envUUID && uuidRegex.test(envUUID)) ? envUUID.toLowerCase() : [userIDMD5.slice(0, 8), userIDMD5.slice(8, 12), '4' + userIDMD5.slice(13, 16), userIDMD5.slice(16, 20), userIDMD5.slice(20)].join('-');
+        const userID = (envUUID && uuidRegex.test(envUUID)) ? envUUID.toLowerCase() : [userIDMD5.slice(0, 8), userIDMD5.slice(8, 12), '4' + userIDMD5.slice(13, 16), '8' + userIDMD5.slice(17, 20), userIDMD5.slice(20)].join('-');
         const host = env.HOST ? env.HOST.toLowerCase().replace(/^https?:\/\//, '').split('/')[0].split(':')[0] : url.hostname;
         if (env.PROXYIP) {
             const proxyIPs = await 整理成数组(env.PROXYIP);


### PR DESCRIPTION
This pull request updates the logic for generating a fallback UUID in the `_worker.js` file. The change ensures that the fallback UUID conforms more closely to the standard UUID version 4 format by altering how the variant field is set.

UUID generation fix:

* Changed the fallback UUID construction to set the variant field correctly by prefixing the fourth segment with `'8'` instead of using a substring from the MD5 hash, improving compliance with the UUID v4 specification.