### PR TITLE
fix: 优化批量替换域名函数，随机化主机选择以提高多样性

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -870,9 +870,10 @@ function 随机替换通配符(h) {
 }
 
 function 批量替换域名(内容, hosts, 每组数量 = 2) {
+    const 打乱后数组 = [...hosts].sort(() => Math.random() - 0.5);
     let count = 0, currentRandomHost = null;
     return 内容.replace(/example\.com/g, () => {
-        if (count % 每组数量 === 0) currentRandomHost = 随机替换通配符(hosts[Math.floor(Math.random() * hosts.length)]);
+        if (count % 每组数量 === 0) currentRandomHost = 随机替换通配符(打乱后数组[count % 打乱后数组.length]);
         count++;
         return currentRandomHost;
     });


### PR DESCRIPTION
This pull request updates the logic for replacing domain names in the `批量替换域名` function to ensure a more randomized and evenly distributed selection of replacement hosts. Instead of picking a random host each time, the function now shuffles the list of hosts at the start and cycles through them in a randomized order for each group.

Improvements to domain replacement logic:

* The `批量替换域名` function now creates a shuffled copy of the `hosts` array and selects hosts from this shuffled list, leading to more even and randomized distribution of replacements.