### PR TITLE
fix: 修正批量替换域名函数中的随机主机选择逻辑

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -900,7 +900,7 @@ function 批量替换域名(内容, hosts, 每组数量 = 2) {
     const 打乱后数组 = [...hosts].sort(() => Math.random() - 0.5);
     let count = 0, currentRandomHost = null;
     return 内容.replace(/example\.com/g, () => {
-        if (count % 每组数量 === 0) currentRandomHost = 随机替换通配符(打乱后数组[count % 打乱后数组.length]);
+        if (count % 每组数量 === 0) currentRandomHost = 随机替换通配符(打乱后数组[Math.floor(count / 每组数量) % 打乱后数组.length]);
         count++;
         return currentRandomHost;
     });


### PR DESCRIPTION
This pull request makes a targeted improvement to the domain replacement logic in the `批量替换域名` function. The update ensures that each group of replacements uses a new host from the shuffled list in a more predictable and balanced way.

**Domain replacement logic improvement:**

* Updated the index calculation for selecting a new host in each group, so that every `每组数量` replacements use the same host before moving to the next one in the shuffled `hosts` array. This change provides a more even distribution of hosts across replacements.