### PR TITLE
fix: 优化反代请求头处理，增强响应内容类型检查

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -348,10 +348,17 @@ export default {
         try {
             const 反代URL = new URL(伪装页URL), 新请求头 = new Headers(request.headers);
             新请求头.set('Host', 反代URL.host);
-            if (新请求头.has('Referer')) { const u = new URL(新请求头.get('Referer')); 新请求头.set('Referer', 反代URL.protocol + '//' + 反代URL.host + u.pathname + u.search); }
-            if (新请求头.has('Origin')) 新请求头.set('Origin', 反代URL.protocol + '//' + 反代URL.host);
+            新请求头.set('Referer', 反代URL.origin);
+            新请求头.set('Origin', 反代URL.origin);
             if (!新请求头.has('User-Agent') && UA && UA !== 'null') 新请求头.set('User-Agent', UA);
-            return fetch(new Request(反代URL.protocol + 反代URL.host + url.pathname + url.search, { method: request.method, headers: 新请求头, body: request.body, cf: request.cf }));
+            const 反代响应 = await fetch(反代URL.origin + url.pathname + url.search, { method: request.method, headers: 新请求头, body: request.body, cf: request.cf });
+            const 内容类型 = 反代响应.headers.get('content-type') || '';
+            // 只处理文本类型的响应
+            if (/text|javascript|json|xml/.test(内容类型)) {
+                const 响应内容 = (await 反代响应.text()).replaceAll(反代URL.host, url.host);
+                return new Response(响应内容, { status: 反代响应.status, headers: { ...Object.fromEntries(反代响应.headers), 'Cache-Control': 'no-store' } });
+            }
+            return 反代响应;
         } catch (error) { }
         return new Response(await nginx(), { status: 200, headers: { 'Content-Type': 'text/html; charset=UTF-8' } });
     }


### PR DESCRIPTION
This pull request updates the proxy logic in `_worker.js` to improve how request and response headers are set and to handle text-based responses more securely. The changes ensure that `Referer` and `Origin` headers are consistently set, and that proxied text responses have their hostnames rewritten and are not cached.

Header handling improvements:
* The `Referer` and `Origin` headers are now always set to the proxy target's origin, simplifying and standardizing their values.
* The logic for setting the `User-Agent` header remains unchanged, but is now more clearly separated from the other header modifications.

Response handling enhancements:
* For responses with a text-based content type (including text, JavaScript, JSON, or XML), the response body is rewritten to replace the proxied host with the original host, and a `Cache-Control: no-store` header is added to prevent caching.
* Non-text responses are returned as-is from the proxied server.