### PR TITLE
fix: 修改订阅请求参数判断逻辑，优化对b64和base64的处理

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -214,7 +214,7 @@ export default {
                             "Subscription-Userinfo": `upload=${pagesSum}; download=${workersSum}; total=${total}; expire=${expire}`,
                             "Cache-Control": "no-store",
                         };
-                        const isSubConverterRequest = request.headers.has('b64') || request.headers.has('base64') || request.headers.get('subconverter-request') || request.headers.get('subconverter-version') || ua.includes('subconverter') || ua.includes(('CF-Workers-SUB').toLowerCase());
+                        const isSubConverterRequest = url.searchParams.has('b64') || url.searchParams.has('base64') || request.headers.get('subconverter-request') || request.headers.get('subconverter-version') || ua.includes('subconverter') || ua.includes(('CF-Workers-SUB').toLowerCase());
                         const 订阅类型 = isSubConverterRequest
                             ? 'mixed'
                             : url.searchParams.has('target')
@@ -320,7 +320,7 @@ export default {
 
                         if (!ua.includes('subconverter')) 订阅内容 = 批量替换域名(订阅内容.replace(/00000000-0000-4000-8000-000000000000/g, config_JSON.UUID), config_JSON.HOSTS)
 
-                        if (!ua.includes('mozilla') && 订阅类型 === 'mixed') 订阅内容 = btoa(订阅内容);
+                        if (订阅类型 === 'mixed' && (!ua.includes('mozilla') || url.searchParams.has('b64') || url.searchParams.has('base64'))) 订阅内容 = btoa(订阅内容);
 
                         if (订阅类型 === 'singbox') {
                             订阅内容 = Singbox订阅配置文件热补丁(订阅内容);


### PR DESCRIPTION
This pull request updates the logic for detecting and handling subscription conversion requests in `_worker.js`. The changes improve how the code determines if a request is from a subconverter client and when to encode the subscription content.

**Improvements to subconverter request detection and encoding:**

* Changed detection of `b64` and `base64` parameters from request headers to URL search parameters in the `isSubConverterRequest` logic, making the check more accurate for typical client requests.
* Updated the logic for base64-encoding the subscription content (`订阅内容`) so that encoding is applied for `mixed` type subscriptions if the user agent is not Mozilla, or if the `b64` or `base64` search parameters are present, ensuring better compatibility with various clients.