### PR TITLE
fix: 更新Clash订阅配置文件热补丁，优化ECH启用逻辑并调整fallback DNS服务器

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -786,6 +786,8 @@ async function httpConnect(targetHost, targetPort, initialData) {
 }
 //////////////////////////////////////////////////功能性函数///////////////////////////////////////////////
 function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null, ECH启用 = false) {
+    if (!ECH启用) return Clash_原始订阅内容;
+
     const clash_yaml = `dns:
   enable: true
   default-nameserver:
@@ -797,10 +799,12 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     - https://sm2.doh.pub/dns-query
     - https://dns.alidns.com/dns-query
   fallback:
-    - 'https://dns.google/dns-query'
-    - 'https://1.1.1.1/dns-query'
+    - 8.8.4.4
+    - 101.101.101.101
+    - 208.67.220.220
   fallback-filter:
     geoip: true
+    domain: [+.google.com, +.facebook.com, +.youtube.com]
     ipcidr:
       - 240.0.0.0/4
       - 0.0.0.0/32
@@ -810,7 +814,7 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     - https://doh.cmliussss.net/CMLiussss
 ` + Clash_原始订阅内容;
 
-    if (!uuid || !ECH启用) return clash_yaml;
+    if (!uuid) return clash_yaml;
     const lines = clash_yaml.split('\n');
     const processedLines = [];
     let i = 0;


### PR DESCRIPTION
This pull request updates the `Clash订阅配置文件热补丁` function in `_worker.js` to improve how DNS configuration is patched and to refine the logic for applying ECH-related changes. The most important changes are:

**Logic Changes:**

* The function now immediately returns the original Clash subscription content if ECH is not enabled, preventing unnecessary processing when ECH is disabled.
* The check for `uuid` is now separated from the ECH check, so the YAML patching logic is only skipped if `uuid` is falsy, regardless of the ECH setting.

**DNS Configuration Updates:**

* The DNS `fallback` list in the YAML template has been updated to use plain IP addresses (`8.8.4.4`, `101.101.101.101`, `208.67.220.220`) instead of HTTPS DNS endpoints.
* A `domain` filter has been added to the `fallback-filter` section, specifically targeting Google, Facebook, and YouTube domains.