### PR TITLE
fix: 更新Clash订阅配置文件热补丁，优化ECH链接生成逻辑并使用常量替代硬编码

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1,6 +1,6 @@
 ﻿import { connect } from "cloudflare:sockets";
 let config_JSON, 反代IP = '', 启用SOCKS5反代 = null, 启用SOCKS5全局反代 = false, 我的SOCKS5账号 = '', parsedSocks5Address = {};
-let 缓存反代IP, 缓存反代解析数组, 缓存反代数组索引 = 0, 启用反代兜底 = true;
+let 缓存反代IP, 缓存反代解析数组, 缓存反代数组索引 = 0, 启用反代兜底 = true, ECH_DOH = 'https://doh.cmliussss.net/CMLiussss';
 let SOCKS5白名单 = ['*tapecontent.net', '*cloudatacdn.com', '*loadshare.org', '*cdn-centaurus.com', 'scholar.google.com'];
 const Pages静态页面 = 'https://edt-pages.github.io';
 ///////////////////////////////////////////////////////主程序入口///////////////////////////////////////////////
@@ -279,7 +279,7 @@ export default {
                                     return new Response('优选订阅生成器异常：' + error.message, { status: 403 });
                                 }
                             }
-                            const ECHLINK参数 = config_JSON.ECH ? '&ech=' + encodeURIComponent(await getECH(config_JSON.HOST)) : '';
+                            const ECHLINK参数 = config_JSON.ECH ? `&ech=${encodeURIComponent(ECH_DOH)}` : '';
                             订阅内容 = 其他节点LINK + 完整优选IP.map(原始地址 => {
                                 // 统一正则: 匹配 域名/IPv4/IPv6地址 + 可选端口 + 可选备注
                                 // 示例: 
@@ -811,7 +811,7 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     geoip-code: CN
   proxy-server-nameserver:
     - https://doh.cmliussss.com/CMLiussss
-    - https://doh.cmliussss.net/CMLiussss
+    - ${ECH_DOH}
 ` + Clash_原始订阅内容;
 
     if (!uuid) return clash_yaml;
@@ -1375,7 +1375,7 @@ async function 读取config_JSON(env, hostname, userID, path, 重置配置 = fal
     if (!config_JSON.Fingerprint) config_JSON.Fingerprint = "chrome";
     if (!config_JSON.ECH) config_JSON.ECH = false;
     else config_JSON.优选订阅生成.SUBUpdateTime = 1; // 启用 ECH 时强制将订阅更新时间改为 1 小时
-    const ECHLINK参数 = config_JSON.ECH ? '&ech=' + encodeURIComponent(await getECH(config_JSON.HOST)) : '';
+    const ECHLINK参数 = config_JSON.ECH ? `&ech=${encodeURIComponent(ECH_DOH)}` : '';
     config_JSON.LINK = `${config_JSON.协议类型}://${userID}@${host}:443?security=tls&type=${config_JSON.传输协议 + ECHLINK参数}&host=${host}&fp=${config_JSON.Fingerprint}&sni=${host}&path=${encodeURIComponent(config_JSON.启用0RTT ? config_JSON.PATH + '?ed=2560' : config_JSON.PATH) + TLS分片参数}&encryption=none${config_JSON.跳过证书验证 ? '&insecure=1&allowInsecure=1' : ''}#${encodeURIComponent(config_JSON.优选订阅生成.SUBNAME)}`;
     config_JSON.优选订阅生成.TOKEN = await MD5MD5(hostname + userID);
 


### PR DESCRIPTION
This pull request updates the handling of the ECH (Encrypted Client Hello) DNS-over-HTTPS endpoint in the `_worker.js` file. The main change is to use a single constant, `ECH_DOH`, for the ECH DoH endpoint URL throughout the code, which simplifies maintenance and ensures consistency.

**ECH DoH Endpoint Handling:**

* Introduced a new constant, `ECH_DOH`, set to `'https://doh.cmliussss.net/CMLiussss'`, and replaced all hardcoded ECH DoH URLs in the code with this constant.
* Updated the generation of ECH-related link parameters to use the `ECH_DOH` constant instead of dynamically fetching or hardcoding the endpoint. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL282-R282) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1378-R1378)
* Modified the Clash subscription configuration patching to use the `ECH_DOH` constant in the list of DoH servers, ensuring the endpoint is consistent and easily configurable.