### PR TITLE
fix: 修正快速订阅逻辑，确保路径区分大小写

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -31,7 +31,7 @@ export default {
             if (env.KV && typeof env.KV.get === 'function') {
                 const 访问路径 = url.pathname.slice(1).toLowerCase();
                 const 区分大小写访问路径 = url.pathname.slice(1);
-                if (访问路径 === 加密秘钥 && 加密秘钥 !== '勿动此默认密钥，有需求请自行通过添加变量KEY进行修改') {//快速订阅
+                if (区分大小写访问路径 === 加密秘钥 && 加密秘钥 !== '勿动此默认密钥，有需求请自行通过添加变量KEY进行修改') {//快速订阅
                     const params = new URLSearchParams(url.search);
                     params.set('token', await MD5MD5(host + userID));
                     return new Response('重定向中...', { status: 302, headers: { 'Location': `/sub?${params.toString()}` } });


### PR DESCRIPTION
This pull request makes a targeted fix to the URL path matching logic in `_worker.js`. The change ensures that the path comparison for the encryption key is case-sensitive, which can help prevent unintended access due to case-insensitive matches.

**Access control improvement:**

* Changed the comparison from using a lowercased path (`访问路径`) to a case-sensitive path (`区分大小写访问路径`) when checking against the encryption key to enforce stricter access control.