### PR TITLE
Beta2.0

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -790,7 +790,7 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     if (!ECH启用 || HOSTS.length === 0) return Clash_原始订阅内容;
 
     // 生成 HOSTS 的 nameserver-policy 条目
-    const hostsEntries = HOSTS.map(host => `    "${host}":\n      - https://doh.cmliussss.com/CMLiussss\n      - ${ECH_DOH}`).join('\n');
+    const hostsEntries = HOSTS.map(host => `    "${host}":\n      - tls://8.8.8.8\n      - https://doh.cmliussss.com/CMLiussss\n      - ${ECH_DOH}`).join('\n');
 
     // 完整的 DNS 配置块（用于没有 dns: 字段时添加）
     const fullDnsBlock = `dns:


### PR DESCRIPTION
This pull request enhances the handling of Clash subscription configuration files by enabling dynamic injection of DNS `nameserver-policy` entries for specified hosts when ECH is enabled. The main changes focus on making the DNS configuration more flexible and robust, especially when custom host policies are required.

**Clash subscription configuration enhancements:**

* The `Clash订阅配置文件热补丁` function now accepts a `HOSTS` parameter and injects a `nameserver-policy` block for each host when ECH is enabled and the `HOSTS` list is not empty.
* Improved logic to detect and modify the presence of `dns:` and `nameserver-policy:` blocks in the YAML, ensuring that host-specific DNS policies are correctly inserted whether or not those blocks previously existed.
* The API call that generates Clash subscription content now passes the `HOSTS` array from the configuration JSON, enabling the above enhancements.