### PR TITLE
Beta2.0

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -787,7 +787,7 @@ async function httpConnect(targetHost, targetPort, initialData) {
 }
 //////////////////////////////////////////////////功能性函数///////////////////////////////////////////////
 function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null, ECH启用 = false, HOSTS = []) {
-    let clash_yaml = Clash_原始订阅内容;
+    let clash_yaml = Clash_原始订阅内容.replace(/mode:\s*Rule\b/g, 'mode: rule');
 
     // 基础 DNS 配置块（不含 nameserver-policy）
     const baseDnsBlock = `dns:


### PR DESCRIPTION
This pull request refactors the `Clash订阅配置文件热补丁` function in `_worker.js` to improve the handling of DNS configuration and ECH (Encrypted Client Hello) options in Clash subscription files. The main changes ensure that the DNS block is always present, and that ECH-related settings are applied more reliably when enabled.

DNS configuration improvements:
* The function now always ensures a `dns:` configuration block exists, regardless of whether ECH is enabled or hosts are provided. This prevents missing DNS configuration in the generated Clash YAML. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL790-R793) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL817-R829)
* The DNS block is built using a simplified `baseDnsBlock` without the `nameserver-policy` section, which is added separately only when needed. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL790-R793) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL817-R829)

ECH and nameserver-policy handling:
* The addition of `nameserver-policy` entries for specified hosts is now conditional on both ECH being enabled and the hosts list being non-empty, ensuring correct behavior.
* The logic for injecting `nameserver-policy` entries within the DNS block is improved to prevent duplication and ensure proper placement. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL838) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL868-R874)
* The function now returns early if either `uuid` is missing or ECH is not enabled, streamlining the flow and preventing unnecessary processing.