### PR TITLE
Beta2.0

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -824,7 +824,7 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     // 如果 ECH 启用且 HOSTS 有效，添加 nameserver-policy
     if (ECH启用 && HOSTS.length > 0) {
         // 生成 HOSTS 的 nameserver-policy 条目
-        const hostsEntries = HOSTS.map(host => `    "${host}":\n      - tls://8.8.8.8\n      - https://doh.cmliussss.com/CMLiussss\n      - ${ECH_DOH}`).join('\n');
+        const hostsEntries = HOSTS.map(host => `    "${host}":\n      - tls://223.5.5.5\n      - tls://8.8.8.8\n      - https://doh.cmliussss.com/CMLiussss\n      - ${ECH_DOH}`).join('\n');
 
         // 检查是否存在 nameserver-policy:
         const hasNameserverPolicy = /^\s{2}nameserver-policy:\s*(?:\n|$)/m.test(clash_yaml);


### PR DESCRIPTION
This pull request updates the handling of DNS and ECH (Encrypted Client Hello) configurations in the Clash and Singbox subscription patching functions. The main improvements are to the DNS server lists for Clash and the default DNS IPs in Singbox, as well as a small ECH configuration comment for future compatibility.

DNS configuration improvements:

* In the `Clash订阅配置文件热补丁` function in `_worker.js`, the default DNS server list for each host in the `nameserver-policy` now includes `tls://223.5.5.5` in addition to the existing servers, improving DNS redundancy and reliability.
* In the `Singbox订阅配置文件热补丁` function in `_worker.js`, the default DNS IPs `1.1.1.1` and `1.0.0.1` are replaced with `8.8.8.8` and `8.8.4.4` respectively, ensuring the configuration uses Google's public DNS servers by default.

ECH configuration:

* Added a commented-out `query_server_name` field in the ECH configuration block for Singbox, with a note indicating it will be used once version 1.13.0+ is available.