### PR TITLE
Beta2.0

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -799,9 +799,8 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
   nameserver:
     - https://sm2.doh.pub/dns-query
     - https://dns.alidns.com/dns-query
-  fallback:
+  fallback:${ECH_DNS ? `\n    - ${ECH_DNS}` : ''}
     - 8.8.4.4
-    - 101.101.101.101
     - 208.67.220.220
   fallback-filter:
     geoip: true
@@ -826,7 +825,7 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     // 如果 ECH 启用且 HOSTS 有效，添加 nameserver-policy
     if (ECH启用 && HOSTS.length > 0) {
         // 生成 HOSTS 的 nameserver-policy 条目
-        const hostsEntries = HOSTS.map(host => `    "${host}":\n      - https://doh.cm.edu.kg/CMLiussss${ECH_DNS ? `\n      - ${ECH_DNS}` : ''}\n      - tls://223.5.5.5\n      - tls://8.8.8.8`).join('\n');
+        const hostsEntries = HOSTS.map(host => `    "${host}":${ECH_DNS ? `\n      - ${ECH_DNS}` : ''}\n      - https://doh.cm.edu.kg/CMLiussss`).join('\n');
 
         // 检查是否存在 nameserver-policy:
         const hasNameserverPolicy = /^\s{2}nameserver-policy:\s*(?:\n|$)/m.test(clash_yaml);


### PR DESCRIPTION
This pull request introduces several improvements and adjustments to the Clash configuration file patching logic and the configuration JSON reading function. The main changes focus on enhancing DNS fallback and nameserver-policy handling, as well as improving the initialization of certain configuration fields to ensure more robust defaults.

**Clash DNS and Nameserver Policy Improvements:**

* The `fallback` DNS list in the Clash configuration now conditionally includes the `ECH_DNS` entry if it is defined, and removes the `101.101.101.101` entry to streamline DNS options. (`_worker.js`, [_worker.jsL802-L804](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL802-L804))
* The `nameserver-policy` entries for each host now prioritize the `ECH_DNS` entry (if present) and update the fallback DoH server to `https://doh.cm.edu.kg/CMLiussss`, ensuring more consistent and secure DNS resolution for listed hosts. (`_worker.js`, [_worker.jsL829-R828](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL829-R828))

**Configuration JSON Defaults:**

* The configuration JSON reading function now sets default values for `随机路径` (random path) and `启用0RTT` (enable 0-RTT) as `false` if they are not already defined, and ensures `TLS分片` (TLS fragmentation) is set to `null` unless explicitly specified. This helps prevent undefined or unexpected behavior due to missing config fields. (`_worker.js`, [_worker.jsR1439-R1442](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR1439-R1442))