### PR TITLE
fix: 更新Clash订阅配置文件热补丁，修复fallback配置并添加新的ASN映射

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -799,7 +799,7 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
   nameserver:
     - https://sm2.doh.pub/dns-query
     - https://dns.alidns.com/dns-query
-  fallback:${ECH_DNS ? `\n    - ${ECH_DNS}` : ''}
+  fallback:
     - 8.8.4.4
     - 208.67.220.220
   fallback-filter:
@@ -1498,9 +1498,9 @@ async function 读取config_JSON(env, hostname, userID, path, 重置配置 = fal
 }
 
 async function 生成随机IP(request, count = 16, 指定端口 = -1) {
-    const asnMap = { '9808': 'cmcc', '4837': 'cu', '4134': 'ct' }, asn = request.cf.asn;
+    const asnMap = { '9808': 'cmcc', '4837': 'cu', '17623': 'cu', '4134': 'ct' }, asn = request.cf.asn;
     const cidr_url = asnMap[asn] ? `https://raw.githubusercontent.com/cmliu/cmliu/main/CF-CIDR/${asnMap[asn]}.txt` : 'https://raw.githubusercontent.com/cmliu/cmliu/main/CF-CIDR.txt';
-    const cfname = { '9808': 'CF移动优选', '4837': 'CF联通优选', '4134': 'CF电信优选' }[asn] || 'CF官方优选';
+    const cfname = { '9808': 'CF移动优选', '4837': 'CF联通优选', '17623': 'CF联通优选', '4134': 'CF电信优选' }[asn] || 'CF官方优选';
     const cfport = [443, 2053, 2083, 2087, 2096, 8443];
     let cidrList = [];
     try { const res = await fetch(cidr_url); cidrList = res.ok ? await 整理成数组(await res.text()) : ['104.16.0.0/13']; } catch { cidrList = ['104.16.0.0/13']; }


### PR DESCRIPTION
This pull request updates the handling of DNS fallback servers in the Clash configuration and improves ASN (Autonomous System Number) mapping for IP generation. The main changes enhance compatibility with more network providers and ensure more reliable DNS fallback options.

**Clash configuration improvements:**

* The `fallback` DNS servers in the Clash configuration are now set explicitly to `8.8.4.4` and `208.67.220.220` instead of being conditionally included based on the `ECH_DNS` variable.

**ASN mapping enhancements:**

* Added support for ASN `17623` (China Unicom) in both the `asnMap` and `cfname` mappings, ensuring correct CIDR file selection and naming for this provider.