### PR TITLE
Beta2.0

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -803,11 +803,15 @@ function Clash订阅配置文件热补丁(Clash_原始订阅内容, uuid = null,
     - 208.67.220.220
   fallback-filter:
     geoip: true
-    domain: [+.google.com, +.facebook.com, +.youtube.com]
+    geoip-code: CN
     ipcidr:
       - 240.0.0.0/4
+      - 127.0.0.1/32
       - 0.0.0.0/32
-    geoip-code: CN
+    domain:
+      - '+.google.com'
+      - '+.facebook.com'
+      - '+.youtube.com'
 `;
 
     // 检查是否存在 dns: 字段（可能在任意行，行首无缩进）


### PR DESCRIPTION
This pull request refines the configuration and logic for DNS fallback filters and Cloudflare IP selection, improving clarity and expanding support for additional ISPs.

**DNS Fallback Filter Improvements:**

* The `fallback-filter` section in the Clash configuration now explicitly lists `geoip-code: CN` before the `domain` field, and the `domain` list is expanded to a more readable multi-line format. Additionally, `127.0.0.1/32` is added to the `ipcidr` list for completeness.

**Cloudflare IP Selection Enhancements:**

* The random IP generation function now uses a more structured `ISP配置` mapping, which adds support for ASN `17816` (联通优选) and improves naming clarity for each ISP. The configuration for fetching CIDR lists and naming conventions is now more maintainable and extensible.