### PR TITLE
Beta2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,12 @@
 | **ADMIN** | ✅ | `123456` | 后台管理面板登录密码 |
 | **KEY** | ❌ | `CMLiussss` | 快速订阅路径密钥，访问 `/CMLiussss` 即可快速获取节点 |
 | **UUID** | ❌ | `90cd4a77-141a-43c9-991b-08263cfe9c10` | 强制固定UUID，只支持**UUIDv4**标准格式 |
-| ~~HOST~~ | ❌ | `edt.pages.dev` | ~~强制固定伪装域名~~可通过面板直接设置 |
-| ~~PATH~~ | ❌ | `/` | ~~强制固定伪装路径~~可通过面板直接设置 |
+| ~~HOST~~ | ❌ | `edt.pages.dev` | ~~强制固定伪装域名~~ 可通过面板直接设置 |
+| ~~PATH~~ | ❌ | `/` | ~~强制固定伪装路径~~ 可通过面板直接设置 |
 | **PROXYIP** | ❌ | `proxyip.cmliussss.net:443` | 全局自定义反代 IP  |
 | **URL** | ❌ | `https://cloudflare-error-page-3th.pages.dev` | 默认主页伪装地址（可填写网页 URL 或 `1101`） |
 | **GO2SOCKS5** | ❌ | `blog.cmliussss.com`,`*.ip111.cn`,`*google.com` | 强制走 SOCKS5 的名单 (`*` 为全局，域名用逗号分隔) |
+| **OFF_LOG** | ❌ | `1`或`true` | 默认开启日志记录功能，设置`1`或`true`则关闭日志记录功能 |
 
 ---
 

--- a/_worker.js
+++ b/_worker.js
@@ -1216,6 +1216,7 @@ function Surge订阅配置文件热补丁(content, url, config_JSON) {
 
 async function 请求日志记录(env, request, 访问IP, 请求类型 = "Get_SUB", config_JSON) {
     const KV容量限制 = 4;//MB
+    if (env.OFF_LOG) return;
     try {
         const 当前时间 = new Date();
         const 日志内容 = { TYPE: 请求类型, IP: 访问IP, ASN: `AS${request.cf.asn || '0'} ${request.cf.asOrganization || 'Unknown'}`, CC: `${request.cf.country || 'N/A'} ${request.cf.city || 'N/A'}`, URL: request.url, UA: request.headers.get('User-Agent') || 'Unknown', TIME: 当前时间.getTime() };


### PR DESCRIPTION
This pull request introduces an option to disable logging and improves the handling of remarks in the 优选API IP results. The most important changes are grouped below:

Logging configuration:

* Added the `OFF_LOG` environment variable, allowing users to disable logging by setting it to `1` or `true`. This is documented in `README.md` and implemented in the `请求日志记录` function, which now respects the `OFF_LOG` setting. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR1219)

优选API IP remark handling:

* Improved the processing of 优选API IP results by decoding any remarks in the IP list, ensuring that remarks are human-readable.