### PR TITLE
feat: 添加日志记录功能的条件判断，支持通过环境变量控制日志记录开关

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1215,13 +1215,19 @@ function Surge订阅配置文件热补丁(content, url, config_JSON) {
 }
 
 async function 请求日志记录(env, request, 访问IP, 请求类型 = "Get_SUB", config_JSON) {
-    const KV容量限制 = 4;//MB
-    if (env.OFF_LOG) return;
     try {
         const 当前时间 = new Date();
         const 日志内容 = { TYPE: 请求类型, IP: 访问IP, ASN: `AS${request.cf.asn || '0'} ${request.cf.asOrganization || 'Unknown'}`, CC: `${request.cf.country || 'N/A'} ${request.cf.city || 'N/A'}`, URL: request.url, UA: request.headers.get('User-Agent') || 'Unknown', TIME: 当前时间.getTime() };
+        if (config_JSON.TG.启用) {
+            try {
+                const TG_TXT = await env.KV.get('tg.json');
+                const TG_JSON = JSON.parse(TG_TXT);
+                await sendMessage(TG_JSON.BotToken, TG_JSON.ChatID, 日志内容, config_JSON);
+            } catch (error) { console.error(`读取tg.json出错: ${error.message}`) }
+        }
+        if (env.OFF_LOG && !['0', 'false'].includes(env.OFF_LOG)) return;
         let 日志数组 = [];
-        const 现有日志 = await env.KV.get('log.json');
+        const 现有日志 = await env.KV.get('log.json'), KV容量限制 = 4;//MB
         if (现有日志) {
             try {
                 日志数组 = JSON.parse(现有日志);
@@ -1234,13 +1240,6 @@ async function 请求日志记录(env, request, 访问IP, 请求类型 = "Get_SU
                 } else {
                     日志数组.push(日志内容);
                     while (JSON.stringify(日志数组, null, 2).length > KV容量限制 * 1024 * 1024 && 日志数组.length > 0) 日志数组.shift();
-                }
-                if (config_JSON.TG.启用) {
-                    try {
-                        const TG_TXT = await env.KV.get('tg.json');
-                        const TG_JSON = JSON.parse(TG_TXT);
-                        await sendMessage(TG_JSON.BotToken, TG_JSON.ChatID, 日志内容, config_JSON);
-                    } catch (error) { console.error(`读取tg.json出错: ${error.message}`) }
                 }
             } catch (e) { 日志数组 = [日志内容]; }
         } else { 日志数组 = [日志内容]; }


### PR DESCRIPTION
This pull request refactors the logging logic in the `请求日志记录` function to improve handling of Telegram notifications and the log disabling mechanism. The main changes are the relocation of Telegram notification code, adjustment of log disabling checks, and simplification of the logging process.

Logging and notification improvements:

* Moved the Telegram notification logic to execute before the log disabling check, ensuring notifications are sent even if logging is disabled. (`_worker.js` [_worker.jsL1218-R1230](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1218-R1230))
* Changed the log disabling check to only skip log storage when `env.OFF_LOG` is set, but still allows Telegram notifications if enabled. (`_worker.js` [_worker.jsL1218-R1230](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1218-R1230))
* Removed redundant Telegram notification code from inside the log storage block, preventing duplicate notifications. (`_worker.js` [_worker.jsL1238-L1244](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1238-L1244))

Code clarity and maintenance:

* Moved the `KV容量限制` definition closer to its usage for clarity. (`_worker.js` [_worker.jsL1218-R1230](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1218-R1230))