### PR TITLE
feat: DeBug

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -375,7 +375,8 @@ export default {
 async function 处理WS请求(request, yourUUID) {
     const wssPair = new WebSocketPair();
     const [clientSock, serverSock] = Object.values(wssPair);
-    serverSock.accept();
+    serverSock.accept();// @ts-ignore
+    serverSock.binaryType = 'arraybuffer';
     let remoteConnWrapper = { socket: null };
     let isDnsQuery = false;
     const earlyData = request.headers.get('sec-websocket-protocol') || '';


### PR DESCRIPTION
This pull request makes a small improvement to the WebSocket handling in `_worker.js`. The change sets the `binaryType` of the server-side WebSocket to `'arraybuffer'`, ensuring that binary data is handled correctly.

- WebSocket handling:
  * Sets `serverSock.binaryType` to `'arraybuffer'` after accepting the connection, which ensures that binary messages are received as `ArrayBuffer` objects.