### PR TITLE
feat: 添加优选订阅生成器功能，支持通过环境变量控制

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 | **URL** | ❌ | `https://cloudflare-error-page-3th.pages.dev` | 默认主页伪装地址（可填写网页 URL 或 `1101`） |
 | **GO2SOCKS5** | ❌ | `blog.cmliussss.com`,`*.ip111.cn`,`*google.com` | 强制走 SOCKS5 的名单 (`*` 为全局，域名用逗号分隔) |
 | **OFF_LOG** | ❌ | `1`或`true` | 默认开启日志记录功能，设置`1`或`true`则关闭日志记录功能 |
+| **BEST_SUB** | ❌ | `1`或`true` | 默认关闭作为**优选订阅生成器**的功能，设置`1`或`true`则开启该功能 |
 
 ---
 

--- a/_worker.js
+++ b/_worker.js
@@ -193,10 +193,11 @@ export default {
                     响应.headers.set('Set-Cookie', 'auth=; Path=/; Max-Age=0; HttpOnly');
                     return 响应;
                 } else if (访问路径 === 'sub') {//处理订阅请求
-                    const 订阅TOKEN = await MD5MD5(host + userID);
-                    if (url.searchParams.get('token') === 订阅TOKEN) {
+                    const 订阅TOKEN = await MD5MD5(host + userID), 作为优选订阅生成器 = ['1', 'true'].includes(env.BEST_SUB) && url.searchParams.get('host') === 'example.com' && url.searchParams.get('uuid') === '00000000-0000-4000-8000-000000000000' && UA.toLowerCase().includes('tunnel (https://github.com/cmliu/edge');
+                    if (url.searchParams.get('token') === 订阅TOKEN || 作为优选订阅生成器) {
                         config_JSON = await 读取config_JSON(env, host, userID);
-                        ctx.waitUntil(请求日志记录(env, request, 访问IP, 'Get_SUB', config_JSON));
+                        if (作为优选订阅生成器) ctx.waitUntil(请求日志记录(env, request, 访问IP, 'Get_Best_SUB', config_JSON, false));
+                        else ctx.waitUntil(请求日志记录(env, request, 访问IP, 'Get_SUB', config_JSON));
                         const ua = UA.toLowerCase();
                         const expire = 4102329600;//2099-12-31 到期时间
                         const now = Date.now();
@@ -311,7 +312,7 @@ export default {
                         } else { // 订阅转换
                             const 订阅转换URL = `${config_JSON.订阅转换配置.SUBAPI}/sub?target=${订阅类型}&url=${encodeURIComponent(url.protocol + '//' + url.host + '/sub?target=mixed&token=' + 订阅TOKEN + (url.searchParams.has('sub') && url.searchParams.get('sub') != '' ? `&sub=${url.searchParams.get('sub')}` : ''))}&config=${encodeURIComponent(config_JSON.订阅转换配置.SUBCONFIG)}&emoji=${config_JSON.订阅转换配置.SUBEMOJI}&scv=${config_JSON.跳过证书验证}`;
                             try {
-                                const response = await fetch(订阅转换URL, { headers: { 'User-Agent': 'Subconverter for ' + 订阅类型 + ' edge' + 'tunnel(https://github.com/cmliu/edge' + 'tunnel)' } });
+                                const response = await fetch(订阅转换URL, { headers: { 'User-Agent': 'Subconverter for ' + 订阅类型 + ' edge' + 'tunnel (https://github.com/cmliu/edge' + 'tunnel)' } });
                                 if (response.ok) {
                                     订阅内容 = await response.text();
                                     if (url.searchParams.has('surge') || ua.includes('surge')) 订阅内容 = Surge订阅配置文件热补丁(订阅内容, url.protocol + '//' + url.host + '/sub?token=' + 订阅TOKEN + '&surge', config_JSON);
@@ -321,7 +322,7 @@ export default {
                             }
                         }
 
-                        if (!ua.includes('subconverter')) 订阅内容 = await 批量替换域名(订阅内容.replace(/00000000-0000-4000-8000-000000000000/g, config_JSON.UUID), config_JSON.HOSTS)
+                        if (!ua.includes('subconverter') && !作为优选订阅生成器) 订阅内容 = await 批量替换域名(订阅内容.replace(/00000000-0000-4000-8000-000000000000/g, config_JSON.UUID), config_JSON.HOSTS)
 
                         if (订阅类型 === 'mixed' && (!ua.includes('mozilla') || url.searchParams.has('b64') || url.searchParams.has('base64'))) 订阅内容 = btoa(订阅内容);
 
@@ -1215,7 +1216,7 @@ function Surge订阅配置文件热补丁(content, url, config_JSON) {
     return 输出内容;
 }
 
-async function 请求日志记录(env, request, 访问IP, 请求类型 = "Get_SUB", config_JSON) {
+async function 请求日志记录(env, request, 访问IP, 请求类型 = "Get_SUB", config_JSON, 是否写入KV日志 = true) {
     try {
         const 当前时间 = new Date();
         const 日志内容 = { TYPE: 请求类型, IP: 访问IP, ASN: `AS${request.cf.asn || '0'} ${request.cf.asOrganization || 'Unknown'}`, CC: `${request.cf.country || 'N/A'} ${request.cf.city || 'N/A'}`, URL: request.url, UA: request.headers.get('User-Agent') || 'Unknown', TIME: 当前时间.getTime() };
@@ -1226,7 +1227,8 @@ async function 请求日志记录(env, request, 访问IP, 请求类型 = "Get_SU
                 await sendMessage(TG_JSON.BotToken, TG_JSON.ChatID, 日志内容, config_JSON);
             } catch (error) { console.error(`读取tg.json出错: ${error.message}`) }
         }
-        if (env.OFF_LOG && !['0', 'false'].includes(env.OFF_LOG)) return;
+        是否写入KV日志 = ['1', 'true'].includes(env.OFF_LOG) ? false : 是否写入KV日志;
+        if (!是否写入KV日志) return;
         let 日志数组 = [];
         const 现有日志 = await env.KV.get('log.json'), KV容量限制 = 4;//MB
         if (现有日志) {


### PR DESCRIPTION
This pull request introduces support for a new "优选订阅生成器" (Best Subscription Generator) feature, allowing the service to generate optimized subscriptions under specific conditions. The implementation includes changes to the subscription handling logic, logging, and configuration documentation.

New feature: 优选订阅生成器

* Added `BEST_SUB` configuration option to `README.md`, allowing users to enable the Best Subscription Generator feature by setting it to `1` or `true`.

Subscription handling logic enhancements

* Updated the subscription endpoint in `_worker.js` to support Best Subscription Generator requests by checking for specific conditions in the request and environment variables. When triggered, it logs the event as `Get_Best_SUB` and bypasses domain replacement logic. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL196-R200) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL324-R325)

Logging improvements

* Modified the `请求日志记录` function to accept a `是否写入KV日志` parameter, allowing selective logging for Best Subscription Generator requests. The logic now disables KV logging if `OFF_LOG` is set to `1` or `true`. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1218-R1219) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1229-R1231)