### PR TITLE
feat: 更新优选订阅生成器逻辑，仅支持输出base64类型的订阅

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -217,7 +217,7 @@ export default {
                             "Subscription-Userinfo": `upload=${pagesSum}; download=${workersSum}; total=${total}; expire=${expire}`,
                             "Cache-Control": "no-store",
                         };
-                        const isSubConverterRequest = url.searchParams.has('b64') || url.searchParams.has('base64') || request.headers.get('subconverter-request') || request.headers.get('subconverter-version') || ua.includes('subconverter') || ua.includes(('CF-Workers-SUB').toLowerCase());
+                        const isSubConverterRequest = url.searchParams.has('b64') || url.searchParams.has('base64') || request.headers.get('subconverter-request') || request.headers.get('subconverter-version') || ua.includes('subconverter') || ua.includes(('CF-Workers-SUB').toLowerCase()) || 作为优选订阅生成器;
                         const 订阅类型 = isSubConverterRequest
                             ? 'mixed'
                             : url.searchParams.has('target')


### PR DESCRIPTION
This pull request introduces an update to the logic that determines whether a request should be treated as a SubConverter request in `_worker.js`. The main change is the addition of a new condition to the `isSubConverterRequest` check, which broadens the criteria for identifying these requests.

Enhancement to SubConverter request detection:

* Expanded the `isSubConverterRequest` condition in `_worker.js` to include an additional check (`作为优选订阅生成器`), allowing for more flexible identification of SubConverter requests.