### PR TITLE
fix: remove duplicate headers and reorder by trustworthiness in IP detection chain

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -28,7 +28,7 @@ export default {
 			反代IP = proxyIPs[Math.floor(Math.random() * proxyIPs.length)];
 			启用反代兜底 = false;
 		} else 反代IP = (request.cf.colo + '.PrOxYIp.CmLiUsSsS.nEt').toLowerCase();
-		const 访问IP = request.headers.get('X-Real-IP') || request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || request.headers.get('True-Client-IP') || request.headers.get('Fly-Client-IP') || request.headers.get('X-Appengine-Remote-Addr') || request.headers.get('X-Forwarded-For') || request.headers.get('X-Real-IP') || request.headers.get('X-Cluster-Client-IP') || request.cf?.clientTcpRtt || '未知IP';
+		const 访问IP = request.headers.get('CF-Connecting-IP') || request.headers.get('True-Client-IP') || request.headers.get('X-Real-IP') || request.headers.get('X-Forwarded-For') || request.headers.get('Fly-Client-IP') || request.headers.get('X-Appengine-Remote-Addr') || request.headers.get('X-Cluster-Client-IP') || '未知IP';
 		if (env.GO2SOCKS5) SOCKS5白名单 = await 整理成数组(env.GO2SOCKS5);
 		if (访问路径 === 'version' && url.searchParams.get('uuid') === userID) {// 版本信息接口
 			return new Response(JSON.stringify({ Version: Number(String(Version).replace(/\D+/g, '')) }), { status: 200, headers: { 'Content-Type': 'application/json;charset=utf-8' } });


### PR DESCRIPTION
Fixes #1117

## Changes
- Remove duplicate `X-Real-IP` (appeared at positions 1 and 8)
- Remove duplicate `X-Forwarded-For` (appeared at positions 3 and 7)
- Reorder: Cloudflare-injected headers (`CF-Connecting-IP`, `True-Client-IP`) take priority over user-controllable headers (`X-Real-IP`, `X-Forwarded-For`)

## Before
```js
const 访问IP = request.headers.get('X-Real-IP')           // ← dup
  || request.headers.get('CF-Connecting-IP')
  || request.headers.get('X-Forwarded-For')               // ← dup
  || ... || request.headers.get('X-Forwarded-For')        // ← dup
  || request.headers.get('X-Real-IP') ...                 // ← dup
```

## After
```js
const 访问IP = request.headers.get('CF-Connecting-IP')
  || request.headers.get('True-Client-IP')
  || request.headers.get('X-Real-IP')
  || request.headers.get('X-Forwarded-For')
  || request.headers.get('Fly-Client-IP')
  || request.headers.get('X-Appengine-Remote-Addr')
  || request.headers.get('X-Cluster-Client-IP')
  || '未知IP';
```