### PR TITLE
fix: add Secure and SameSite=Strict flags to auth cookie

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -66,7 +66,7 @@ export default {
 						if (输入密码 === 管理员密码) {
 							// 密码正确，设置cookie并返回成功标记
 							const 响应 = new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json;charset=utf-8' } });
-							响应.headers.set('Set-Cookie', `auth=${await MD5MD5(UA + 加密秘钥 + 管理员密码)}; Path=/; Max-Age=86400; HttpOnly`);
+							响应.headers.set('Set-Cookie', `auth=${await MD5MD5(UA + 加密秘钥 + 管理员密码)}; Path=/; Max-Age=86400; HttpOnly; Secure; SameSite=Strict`);
 							return 响应;
 						}
 					}


### PR DESCRIPTION
Fixes #1119

The auth cookie was missing two critical security attributes:

- **`Secure`**: without it the browser may transmit the cookie over plain HTTP before the 301 redirect fires, exposing the session token.
- **`SameSite=Strict`**: prevents the cookie from being sent on cross-site requests, mitigating CSRF against the `/admin` panel.

Cloudflare Workers always run behind HTTPS so the `Secure` flag is safe to add unconditionally.

```diff
-`auth=${…}; Path=/; Max-Age=86400; HttpOnly`
+`auth=${…}; Path=/; Max-Age=86400; HttpOnly; Secure; SameSite=Strict`
```