### PR TITLE
fix: use random DNS query ID per RFC 1035 §4.1.1

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -3436,7 +3436,7 @@ async function DoH查询(域名, 记录类型, DoH解析服务 = "https://cloudf
 		const qname = 编码域名(域名);
 		const query = new Uint8Array(12 + qname.length + 4);
 		const qview = new DataView(query.buffer);
-		qview.setUint16(0, 0);       // ID
+		qview.setUint16(0, crypto.getRandomValues(new Uint16Array(1))[0]); // ID (random per RFC 1035)
 		qview.setUint16(2, 0x0100);  // Flags: RD=1 (递归查询)
 		qview.setUint16(4, 1);       // QDCOUNT
 		query.set(qname, 12);


### PR DESCRIPTION
Fixes #1120

RFC 1035 §4.1.1 requires a random 16-bit ID in the DNS message header so responses can be matched to their queries.

The previous hardcoded `0` is functionally safe for sequential requests but is technically non-compliant and could cause response-matching failures under concurrent `DoH查询()` calls.

```diff
-qview.setUint16(0, 0);  // ID
+qview.setUint16(0, crypto.getRandomValues(new Uint16Array(1))[0]); // ID (random per RFC 1035)
```

`crypto.getRandomValues()` is natively available in the Cloudflare Workers runtime.