### PR TITLE
fix: read CF API credentials from POST body to prevent URL-based leakage

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -82,20 +82,29 @@ export default {
 					} else if (区分大小写访问路径 === 'admin/getCloudflareUsage') {// 查询请求量
 						try {
 							// 优先从 POST body 读取凭据（避免敏感信息暴露在 URL / 服务器日志中）
-							// 兼容旧版 GET query 参数作为降级方案
+							// 兼容旧版 GET query 参数作为降级方案（已废弃，未来版本将移除）
 							let Email, GlobalAPIKey, AccountID, APIToken;
-							if (request.method === 'POST') {
+							let usingDeprecatedQueryParams = false;
+							if (request.method === 'POST' && (request.headers.get('content-type') || '').includes('application/json')) {
 								try {
 									const body = await request.json();
-									Email = body.Email; GlobalAPIKey = body.GlobalAPIKey;
-									AccountID = body.AccountID; APIToken = body.APIToken;
+									// 统一转换为字符串，防止 GraphQL String! 类型校验失败
+									Email = body.Email != null ? String(body.Email) : undefined;
+									GlobalAPIKey = body.GlobalAPIKey != null ? String(body.GlobalAPIKey) : undefined;
+									AccountID = body.AccountID != null ? String(body.AccountID) : undefined;
+									APIToken = body.APIToken != null ? String(body.APIToken) : undefined;
 								} catch (_) { }
 							}
-							Email = Email ?? url.searchParams.get('Email');
-							GlobalAPIKey = GlobalAPIKey ?? url.searchParams.get('GlobalAPIKey');
-							AccountID = AccountID ?? url.searchParams.get('AccountID');
-							APIToken = APIToken ?? url.searchParams.get('APIToken');
+							// 降级到 query 参数（已废弃）
+							if (!Email && !GlobalAPIKey && !AccountID && !APIToken) {
+								Email = url.searchParams.get('Email') ?? undefined;
+								GlobalAPIKey = url.searchParams.get('GlobalAPIKey') ?? undefined;
+								AccountID = url.searchParams.get('AccountID') ?? undefined;
+								APIToken = url.searchParams.get('APIToken') ?? undefined;
+								if (Email || GlobalAPIKey || AccountID || APIToken) usingDeprecatedQueryParams = true;
+							}
 							const Usage_JSON = await getCloudflareUsage(Email, GlobalAPIKey, AccountID, APIToken);
+							if (usingDeprecatedQueryParams) Usage_JSON._warning = 'Passing credentials via URL query parameters is deprecated and will be removed in a future version. Please switch to POST with a JSON body.';
 							return new Response(JSON.stringify(Usage_JSON, null, 2), { status: 200, headers: { 'Content-Type': 'application/json' } });
 						} catch (err) {
 							const errorResponse = { msg: '查询请求量失败，失败原因：' + err.message, error: err.message };

--- a/_worker.js
+++ b/_worker.js
@@ -81,7 +81,21 @@ export default {
 						return new Response(读取日志内容, { status: 200, headers: { 'Content-Type': 'application/json;charset=utf-8' } });
 					} else if (区分大小写访问路径 === 'admin/getCloudflareUsage') {// 查询请求量
 						try {
-							const Usage_JSON = await getCloudflareUsage(url.searchParams.get('Email'), url.searchParams.get('GlobalAPIKey'), url.searchParams.get('AccountID'), url.searchParams.get('APIToken'));
+							// 优先从 POST body 读取凭据（避免敏感信息暴露在 URL / 服务器日志中）
+							// 兼容旧版 GET query 参数作为降级方案
+							let Email, GlobalAPIKey, AccountID, APIToken;
+							if (request.method === 'POST') {
+								try {
+									const body = await request.json();
+									Email = body.Email; GlobalAPIKey = body.GlobalAPIKey;
+									AccountID = body.AccountID; APIToken = body.APIToken;
+								} catch (_) { }
+							}
+							Email = Email ?? url.searchParams.get('Email');
+							GlobalAPIKey = GlobalAPIKey ?? url.searchParams.get('GlobalAPIKey');
+							AccountID = AccountID ?? url.searchParams.get('AccountID');
+							APIToken = APIToken ?? url.searchParams.get('APIToken');
+							const Usage_JSON = await getCloudflareUsage(Email, GlobalAPIKey, AccountID, APIToken);
 							return new Response(JSON.stringify(Usage_JSON, null, 2), { status: 200, headers: { 'Content-Type': 'application/json' } });
 						} catch (err) {
 							const errorResponse = { msg: '查询请求量失败，失败原因：' + err.message, error: err.message };


### PR DESCRIPTION
Fixes #1121

The `/admin/getCloudflareUsage` endpoint accepted `GlobalAPIKey` and `APIToken` as GET query parameters. These values appear in:
- Cloudflare Workers request logs
- Browser history / address-bar autocomplete
- HTTP `Referer` headers forwarded to any third-party resource on the admin page

`GlobalAPIKey` is a Cloudflare account-level credential; leaking it can lead to full account compromise.

## Change
Credentials are now read from a JSON **POST body** first. GET query parameters are kept as a backwards-compatible fallback so existing callers are not immediately broken.

Frontend callers should migrate to:
```js
fetch("/admin/getCloudflareUsage", {
  method: "POST",
  headers: { "Content-Type": "application/json" },
  body: JSON.stringify({ Email, GlobalAPIKey, AccountID, APIToken })
});
```