### PR TITLE
feat: 更新版本号并优化TLS 1.3解密和加密逻辑，修复数据处理流程

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1,4 +1,4 @@
-﻿const Version = '2026-04-16 04:47:24';
+﻿const Version = '2026-04-17 01:57:56';
 /*In our project workflow, we first*/ import //the necessary modules, 
 /*then*/ { connect }//to the central server, 
 /*and all data flows*/ from//this single source.
@@ -2723,9 +2723,10 @@ class TlsClient {
 	async decryptTls13Handshake(ciphertext) {
 		const nonce = xorSequenceIntoIv(this.serverHandshakeIv, this.serverSeqNum++),
 			additionalData = tlsBytes(CONTENT_TYPE_APPLICATION_DATA, 3, 3, uint16be(ciphertext.length));
-		if (this.cipherConfig.chacha) return chacha20Poly1305Decrypt(this.serverHandshakeKey, nonce, ciphertext, additionalData);
-		if (!this.serverHandshakeCryptoKey) this.serverHandshakeCryptoKey = await importAesGcmKey(this.serverHandshakeKey, ["decrypt"]);
-		return aesGcmDecryptWithKey(this.serverHandshakeCryptoKey, nonce, ciphertext, additionalData)
+		const decrypted = this.cipherConfig.chacha ? await chacha20Poly1305Decrypt(this.serverHandshakeKey, nonce, ciphertext, additionalData) : await aesGcmDecryptWithKey(this.serverHandshakeCryptoKey || (this.serverHandshakeCryptoKey = await importAesGcmKey(this.serverHandshakeKey, ["decrypt"])), nonce, ciphertext, additionalData);
+		let innerTypeIndex = decrypted.length - 1;
+		for (; innerTypeIndex >= 0 && !decrypted[innerTypeIndex];) innerTypeIndex--;
+		return innerTypeIndex < 0 ? EMPTY_BYTES : decrypted.slice(0, innerTypeIndex + 1)
 	}
 	async encryptTls13(data) {
 		const plaintext = concatBytes(data, [CONTENT_TYPE_APPLICATION_DATA]),
@@ -2739,9 +2740,15 @@ class TlsClient {
 		const nonce = xorSequenceIntoIv(this.serverAppIv, this.serverSeqNum++),
 			additionalData = tlsBytes(CONTENT_TYPE_APPLICATION_DATA, 3, 3, uint16be(ciphertext.length)),
 			plaintext = this.cipherConfig.chacha ? await chacha20Poly1305Decrypt(this.serverAppKey, nonce, ciphertext, additionalData) : await aesGcmDecryptWithKey(this.serverAppCryptoKey || (this.serverAppCryptoKey = await importAesGcmKey(this.serverAppKey, ["decrypt"])), nonce, ciphertext, additionalData);
+		let innerTypeIndex = plaintext.length - 1;
+		for (; innerTypeIndex >= 0 && !plaintext[innerTypeIndex];) innerTypeIndex--;
+		if (innerTypeIndex < 0) return {
+			data: EMPTY_BYTES,
+			type: 0
+		};
 		return {
-			data: plaintext.subarray(0, plaintext.length - 1),
-			type: plaintext[plaintext.length - 1]
+			data: plaintext.slice(0, innerTypeIndex),
+			type: plaintext[innerTypeIndex]
 		}
 	}
 	async write(data) {
@@ -2773,6 +2780,10 @@ class TlsClient {
 				if (!this.isTls13) return this.decryptTls12(record.fragment, CONTENT_TYPE_APPLICATION_DATA);
 				const { data, type } = await this.decryptTls13(record.fragment);
 				if (type === CONTENT_TYPE_APPLICATION_DATA) return data;
+				if (type === CONTENT_TYPE_ALERT) {
+					if (data[1] === ALERT_CLOSE_NOTIFY) return null;
+					throw new Error(`TLS Alert: ${data[1]}`)
+				}
 				if (type !== CONTENT_TYPE_HANDSHAKE) continue;
 				let message;
 				for (this.handshakeParser.feed(data); message = this.handshakeParser.next();)


### PR DESCRIPTION
This pull request updates the TLS 1.3 decryption logic in the `TlsClient` class within `_worker.js` to handle trailing padding bytes more robustly and improves alert handling. The main changes focus on correctly trimming decrypted data, handling empty records, and explicitly processing TLS alert messages.

**TLS 1.3 decryption and alert handling improvements:**

* Refactored both `decryptTls13Handshake` and `decryptTls13` methods to strip trailing zero padding bytes from decrypted records, returning only the actual content. This prevents issues with extraneous padding bytes affecting higher-level parsing. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2726-R2729) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR2743-R2751)
* Updated the TLS 1.3 record decryption logic to handle empty records gracefully by returning empty data and a type of 0, improving robustness.
* Added explicit handling for TLS alerts: if an alert is received, the code now throws an error with the alert description, or returns `null` for a `close_notify` alert, ensuring proper connection teardown and error reporting.

**Other changes:**

* Updated the `Version` string at the top of `_worker.js` to reflect the latest change timestamp.