### PR TITLE
为优选IP增加随机ID的功能

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -335,6 +335,9 @@ export default {
 												const 地址备注分离 = 元素.split('#');
 												其他节点.push(地址备注分离[0] + '#' + encodeURIComponent(decodeURIComponent(地址备注分离[1])));
 											} else 其他节点.push(元素);
+										} else if (元素.includes('{newid()}')) {
+											const 带随机ID的元素 = 元素.replace('{newid()}', crypto.randomUUID().replace(/-/g, ''));
+											优选IP.push(带随机ID的元素);
 										} else {
 											优选IP.push(元素);
 										}


### PR DESCRIPTION
当优选IP中出现 "{newid()}" 字符串时，将其替换为随机的uuid，如此可实现每次订阅更新后，优选域名都不一样，如：
<img width="760" height="343" alt="image" src="https://github.com/user-attachments/assets/f5730c42-d36e-4182-8238-02b9a4536067" />
可订阅出这样的优选域名：b18ba04aefc4498591a74b54e7bed344.cf.090227.xyz
其前缀每次都不一样