### PR TITLE
feat: 优化 GO2SOCKS5 白名单逻辑，使其支持 proxyip 并改为追加模式Feat improve go2socks5

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -36,7 +36,7 @@ export default {
 			启用反代兜底 = false;
 		} else 反代IP = (request.cf.colo + '.PrOxYIp.CmLiUsSsS.nEt').toLowerCase();
 		const 访问IP = request.headers.get('CF-Connecting-IP') || request.headers.get('True-Client-IP') || request.headers.get('X-Real-IP') || request.headers.get('X-Forwarded-For') || request.headers.get('Fly-Client-IP') || request.headers.get('X-Appengine-Remote-Addr') || request.headers.get('X-Cluster-Client-IP') || '未知IP';
-		if (env.GO2SOCKS5) SOCKS5白名单 = await 整理成数组(env.GO2SOCKS5);
+		if (env.GO2SOCKS5) SOCKS5白名单 = SOCKS5白名单.concat(await 整理成数组(env.GO2SOCKS5));
 		if (访问路径 === 'version' && url.searchParams.get('uuid') === userID) {// 版本信息接口
 			return new Response(JSON.stringify({ Version: Number(String(Version).replace(/\D+/g, '')) }), { status: 200, headers: { 'Content-Type': 'application/json;charset=utf-8' } });
 		} else if (管理员密码 && upgradeHeader === 'websocket') {// WebSocket代理

--- a/_worker.js
+++ b/_worker.js
@@ -1819,12 +1819,12 @@ async function forwardataTCP(host, portNum, rawData, ws, respHeader, remoteConnW
 	}
 	remoteConnWrapper.retryConnect = async () => connecttoPry(!已通过代理发送首包);
 
-	if (启用SOCKS5反代 && (启用SOCKS5全局反代 || SOCKS5白名单.some(p => new RegExp(`^${p.replace(/\*/g, '.*')}$`, 'i').test(host)))) {
-		log(`[TCP转发] 启用 SOCKS5/HTTP/HTTPS/TURN/SSTP 全局代理`);
+	if ((启用SOCKS5反代 || 反代IP) && (启用SOCKS5全局反代 || SOCKS5白名单.some(p => new RegExp(`^${p.replace(/\*/g, '.*')}$`, 'i').test(host)))) {
+		log(`[TCP转发] 命中代理白名单/全局模式，直接通过代理连接`);
 		try {
 			await connecttoPry();
 		} catch (err) {
-			log(`[TCP转发] SOCKS5/HTTP/HTTPS/TURN/SSTP 代理连接失败: ${err.message}`);
+			log(`[TCP转发] 代理连接失败: ${err.message}`);
 			throw err;
 		}
 	} else {


### PR DESCRIPTION
  * 说明：
       1. 修复了只有在配置 SOCKS5/HTTP 代理时白名单才生效的问题，现在使用 proxyip 也能正确触发白名单跳过直连。
       2. 将 GO2SOCKS5 变量从“覆盖模式”改为“追加模式”，避免设置自定义域名后导致系统默认白名单失效。