### PR TITLE
fix: 修复响应URL生成逻辑

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -647,7 +647,7 @@ async function 处理XHTTP请求(request, yourUUID, 反代上下文 = {}) {
 	// 响应端 padding（官方 ApplyXPaddingToResponse 对应，obfs queryInHeader：头名=本机Padding头，值为含 query 的 URL 形式）
 	// 客户端不校验响应 padding，仅作响应特征混淆；随机长度 100~1000
 	try {
-		const 响应URL = new URL(request.url);
+		const 响应URL = new URL('https://x.invalid/');
 		响应URL.searchParams.set(本机Padding键, 生成XHTTPPadding串(100 + Math.floor(Math.random() * 901)));
 		responseHeaders.set(本机Padding头, 响应URL.toString());
 	} catch (e) { }


### PR DESCRIPTION
This pull request makes a small change to the response padding logic in the `处理XHTTP请求` function. The change ensures that the padding header always uses a fixed dummy URL, which improves consistency and prevents accidental leakage of the original request URL.

- Security and privacy improvement:
  * `async function 处理XHTTP请求` in `_worker.js`: Changed the construction of the response padding URL to always use `'https://x.invalid/'` as the base, rather than the incoming request's URL, to avoid leaking request information in the padding header.