### PR TITLE
sync 内容一致时改为对齐上游，避免 fork 历史永久分叉

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -35,9 +35,10 @@ jobs:
             git push --force-with-lease origin main
           else
             # 有本地修改，保持原来的合并方式，不覆盖任何人的改动
-            git pull --no-rebase upstream main && git push origin main || {
+            if ! git pull --no-rebase upstream main; then
               echo "[Error] 合并上游变更产生冲突，自动同步已暂停，请手动 Sync Fork 并解决冲突。"
               echo "[Error] Merge conflict detected while syncing upstream. Please sync your fork manually and resolve the conflicts."
               exit 1
-            }
+            fi
+            git push origin main
           fi

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Sync upstream changes
         run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,26 +15,28 @@ jobs:
     if: ${{ github.event.repository.fork }}
 
     steps:
-      # Step 1: run a standard checkout action
       - name: Checkout target repo
         uses: actions/checkout@v6
-
-      # Step 2: run the sync action
-      - name: Sync upstream changes
-        id: sync
-        uses: aormsby/fork-sync-with-upstream-action@v3.4.3
         with:
-          upstream_sync_repo: cmliu/edgetunnel
-          upstream_sync_branch: main
-          target_sync_branch: main
-          target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set
+          fetch-depth: 0
 
-          # Set test_mode true to run tests instead of the true action!!
-          test_mode: false
-
-      - name: Sync check
-        if: failure()
+      - name: Sync upstream changes
         run: |
-          echo "[Error] 由于上游仓库的 workflow 文件变更，导致 GitHub 自动暂停了本次自动更新，你需要手动 Sync Fork 一次，详细教程请查看项目README.md "
-          echo "[Error] Due to a change in the workflow file of the upstream repository, GitHub has automatically suspended the scheduled automatic update. You need to manually sync your fork. Please refer to the project README.md for instructions. "
-          exit 1
+          git config user.name "GH Action - Upstream Sync"
+          git config user.email "action@github.com"
+
+          git remote add upstream https://github.com/cmliu/edgetunnel.git
+          git fetch upstream main
+
+          if git diff --quiet HEAD upstream/main; then
+            # 内容和上游一致，直接对齐，顺带清理历史分叉留下的多余 merge commit
+            git reset --hard upstream/main
+            git push --force-with-lease origin main
+          else
+            # 有本地修改，保持原来的合并方式，不覆盖任何人的改动
+            git pull --no-rebase upstream main && git push origin main || {
+              echo "[Error] 合并上游变更产生冲突，自动同步已暂停，请手动 Sync Fork 并解决冲突。"
+              echo "[Error] Merge conflict detected while syncing upstream. Please sync your fork manually and resolve the conflicts."
+              exit 1
+            }
+          fi


### PR DESCRIPTION
Fix #1502

现在 sync 是无条件 merge，一旦 fork 和上游历史分叉（比如上游改写过历史），就只能一直叠 merge commit。改成先比内容：

- 内容一致 → `reset --hard` 对齐上游，顺带清掉历史分叉留下的多余 commit
- 内容有差异 → 走原来的 merge，自己改过代码的 fork 不受影响

顺带去掉了 aormsby 第三方 action 和 `shallow_since`（后者每次都会把旧 commit 误报成新提交）。

判断逻辑在我自己的 fork 上验证过：当前内容和上游一致，会走 reset 分支。
